### PR TITLE
Add 'alloc' feature

### DIFF
--- a/ublox/Cargo.toml
+++ b/ublox/Cargo.toml
@@ -11,6 +11,7 @@ readme = "../README.md"
 [features]
 default = ["std"]
 std = []
+alloc = []
 
 [dependencies]
 chrono = { version = "0.4.19", default-features = false, features = [] }

--- a/ublox/src/lib.rs
+++ b/ublox/src/lib.rs
@@ -62,6 +62,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 pub use crate::{

--- a/ublox/src/parser.rs
+++ b/ublox/src/parser.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 use crate::{
@@ -23,6 +24,7 @@ pub trait UnderlyingBuffer:
     }
 }
 
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl UnderlyingBuffer for Vec<u8> {
     fn clear(&mut self) {
         self.clear();
@@ -137,13 +139,14 @@ impl<'a> UnderlyingBuffer for FixedLinearBuffer<'a> {
 /// If you pass your own buffer, it should be able to store at _least_ 4 bytes. In practice,
 /// you won't be able to do anything useful unless it's at least 36 bytes long (the size
 /// of a NavPosLlh packet).
-pub struct Parser<T = Vec<u8>>
+pub struct Parser<T>
 where
     T: UnderlyingBuffer,
 {
     buf: T,
 }
 
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl core::default::Default for Parser<Vec<u8>> {
     fn default() -> Self {
         Self { buf: Vec::new() }


### PR DESCRIPTION
# Add the 'alloc' Cargo feature

The aim of this PR is to enable true allocator-free compilation for `#![no_std]` targets.

Now that arrays can be directly used as buffers for a `Parser`, it would be nice if the requirement to use a global allocator would be removed entirely for `#![no_std]` targets. This PR adds an `alloc` Cargo feature, enabling the avoiding relying on the `alloc` crate entirely.