### PR TITLE
USB support + RxmRTCM message  added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 *~
+Cargo.lock

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1779,6 +1779,28 @@ mod mon_ver {
     }
 }
 
+#[ubx_packet_recv]
+#[ubx(class = 0x02, id = 0x32, fixed_payload_len = 8)]
+struct RxmRTCM {
+    version: u8,
+    flags: u8,
+    sub_type: u16,
+    ref_station: u16,
+    msg_type: u16,
+}
+
+#[ubx_packet_recv]
+#[ubx(class = 0x0a, id = 0x06, fixed_payload_len = 120)]
+struct MonMsgpp {
+    msg1: [u8; 16],
+    msg2: [u8; 16],
+    msg3: [u8; 16],
+    msg4: [u8; 16],
+    msg5: [u8; 16],
+    msg6: [u8; 16],
+    skipped: [u8; 24],
+}
+
 define_recv_packets!(
     enum PacketRef {
         _ = UbxUnknownPacketRef,
@@ -1806,6 +1828,8 @@ define_recv_packets!(
         InfTest,
         InfDebug,
         MonVer,
-        MonHw
+        MonHw,
+        RxmRTCM,
+        MonMsgpp,
     }
 );

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1789,18 +1789,6 @@ struct RxmRTCM {
     msg_type: u16,
 }
 
-#[ubx_packet_recv]
-#[ubx(class = 0x0a, id = 0x06, fixed_payload_len = 120)]
-struct MonMsgpp {
-    msg1: [u8; 16],
-    msg2: [u8; 16],
-    msg3: [u8; 16],
-    msg4: [u8; 16],
-    msg5: [u8; 16],
-    msg6: [u8; 16],
-    skipped: [u8; 24],
-}
-
 define_recv_packets!(
     enum PacketRef {
         _ = UbxUnknownPacketRef,
@@ -1829,7 +1817,6 @@ define_recv_packets!(
         InfDebug,
         MonVer,
         MonHw,
-        RxmRTCM,
-        MonMsgpp,
+        RxmRTCM
     }
 );

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1781,7 +1781,7 @@ mod mon_ver {
 
 #[ubx_packet_recv]
 #[ubx(class = 0x02, id = 0x32, fixed_payload_len = 8)]
-struct RxmRTCM {
+struct RxmRtcm {
     version: u8,
     flags: u8,
     sub_type: u16,

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1073,6 +1073,7 @@ struct CfgPrtUart {
 pub enum UartPortId {
     Uart1 = 1,
     Uart2 = 2,
+    Usb = 3,
 }
 
 /// Port Configuration for SPI Port

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1817,6 +1817,6 @@ define_recv_packets!(
         InfDebug,
         MonVer,
         MonHw,
-        RxmRTCM
+        RxmRtcm
     }
 );


### PR DESCRIPTION
- Added USB enum to UartPortId so that the USB port can be configured with the CfgPrtUart message.
- Added RxmRTCM message in order to debug RTK solutions that are streaming RTCM corrections to the ublox