### PR TITLE
`str` should not include NULL byte.

### DIFF
--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1783,7 +1783,7 @@ mod mon_ver {
             .iter()
             .position(|x| *x == 0)
             .expect("is_cstr_valid bug?");
-        core::str::from_utf8(&bytes[0..=null_pos])
+        core::str::from_utf8(&bytes[0..null_pos])
             .expect("is_cstr_valid should have prevented this code from running")
     }
 
@@ -1794,7 +1794,7 @@ mod mon_ver {
                 return false;
             }
         };
-        core::str::from_utf8(&bytes[0..=null_pos]).is_ok()
+        core::str::from_utf8(&bytes[0..null_pos]).is_ok()
     }
 
     pub(crate) fn is_extension_valid(payload: &[u8]) -> bool {

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -764,8 +764,8 @@ bitflags! {
     flags = "default_for_builder"
 )]
 struct InfError{
-    #[ubx(map_type = Option<&str>, 
-        may_fail, 
+    #[ubx(map_type = Option<&str>,
+        may_fail,
         is_valid = inf::is_valid,
         from = inf::convert_to_str,
         get_as_ref)]
@@ -780,8 +780,8 @@ struct InfError{
     flags = "default_for_builder"
 )]
 struct InfNotice{
-    #[ubx(map_type = Option<&str>, 
-        may_fail, 
+    #[ubx(map_type = Option<&str>,
+        may_fail,
         is_valid = inf::is_valid,
         from = inf::convert_to_str,
         get_as_ref)]
@@ -796,8 +796,8 @@ struct InfNotice{
     flags = "default_for_builder"
 )]
 struct InfTest{
-    #[ubx(map_type = Option<&str>, 
-        may_fail, 
+    #[ubx(map_type = Option<&str>,
+        may_fail,
         is_valid = inf::is_valid,
         from = inf::convert_to_str,
         get_as_ref)]
@@ -812,8 +812,8 @@ struct InfTest{
     flags = "default_for_builder"
 )]
 struct InfWarning{
-    #[ubx(map_type = Option<&str>, 
-        may_fail, 
+    #[ubx(map_type = Option<&str>,
+        may_fail,
         is_valid = inf::is_valid,
         from = inf::convert_to_str,
         get_as_ref)]
@@ -828,8 +828,8 @@ struct InfWarning{
     flags = "default_for_builder"
 )]
 struct InfDebug{
-    #[ubx(map_type = Option<&str>, 
-        may_fail, 
+    #[ubx(map_type = Option<&str>,
+        may_fail,
         is_valid = inf::is_valid,
         from = inf::convert_to_str,
         get_as_ref)]
@@ -1608,7 +1608,7 @@ struct CfgNavX5 {
     reserved8: [u8; 4],
     reserved9: [u8; 3],
 
-    /// Enable/disable ADR/UDR sensor fusion 
+    /// Enable/disable ADR/UDR sensor fusion
     use_adr: u8,
 }
 


### PR DESCRIPTION
Also, why is `convert_to_str_unchecked` called this when in fact it is very much checked?