### PR TITLE
 add timing cfg frames: `CfgTp5`, `CfgTimeMode2`, `CfgTimeMode3`

### DIFF
--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -999,14 +999,19 @@ bitflags! {
 
 /// Time MODE2 Config Frame (32.10.36.1)
 /// only available on `timing` receivers
-#[ubx_packet_send]
-#[ubx(class = 6, id = 0x3D, fixed_payload_len = 28)]
-struct CfgTMode2 {
+#[ubx_packet_recv_send]
+#[ubx(
+    class = 0x06, 
+    id = 0x3d, 
+    fixed_payload_len = 28, 
+    flags = "default_for_builder"
+)]
+struct CfgTmode2 {
     /// Time transfer modes, see [TimeModes] for details
-    #[ubx(map_type = TimeTransferModes)]
+    #[ubx(map_type = CfgTmode2TimeXferModes, may_fail)]
     time_transfer_mode: u8,
     reserved1: u8,
-    #[ubx(map_type = TimeMode2Flags)] 
+    #[ubx(map_type = CfgTmode2Flags)] 
     flags: u16,
     /// WGS84 ECEF.x coordinate or latitude,
     /// depending on `flags` field 
@@ -1030,12 +1035,12 @@ struct CfgTMode2 {
     survery_in_accur_limit: u32,
 }
 
+/// Time transfer modes (32.10.36)
 #[ubx_extend]
-#[ubx(from, into_raw, rest_reserved)]
+#[ubx(from_unchecked, into_raw, rest_error)]
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq)]
-/// Time transfer modes (32.10.36)
-pub enum TimeTransferModes {
+pub enum CfgTmode2TimeXferModes {
     Disabled = 0,
     SurveyIn = 1,
     /// True position information required
@@ -1043,11 +1048,17 @@ pub enum TimeTransferModes {
     FixedMode = 2,
 }
 
+impl Default for CfgTmode2TimeXferModes {
+    fn default() -> Self {
+        Self::Disabled
+    }
+}
+
 #[ubx_extend_bitflags]
-#[ubx(into_raw, rest_reserved)]
+#[ubx(from, into_raw, rest_reserved)]
 bitflags! {
     #[derive(Default)]
-    pub struct TimeMode2Flags :u16 {
+    pub struct CfgTmode2Flags :u16 {
         /// Position given in LAT/LON/ALT
         /// default being WGS84 ECEF
         const LLA = 0x01;
@@ -1058,12 +1069,17 @@ bitflags! {
 
 /// Time MODE3 Config Frame (32.10.37.1)
 /// only available on `timing` receivers
-#[ubx_packet_send]
-#[ubx(class = 6, id = 0x71, fixed_payload_len = 40)] 
-struct CfgTMode3 {
+#[ubx_packet_recv_send]
+#[ubx(
+    class = 0x06, 
+    id = 0x71, 
+    fixed_payload_len = 40,
+    flags = "default_for_builder"
+)] 
+struct CfgTmode3 {
     version: u8,
     reserved1: u8,
-    #[ubx(map_type = TimeMode3Flags)] 
+    #[ubx(map_type = CfgTmode3Flags)] 
     flags: u16,
     /// WGS84 ECEF.x coordinate or latitude,
     /// depending on `flags` field 
@@ -1105,10 +1121,10 @@ struct CfgTMode3 {
 }
 
 #[ubx_extend_bitflags]
-#[ubx(into_raw, rest_reserved)]
+#[ubx(from, into_raw, rest_reserved)]
 bitflags! {
     #[derive(Default)]
-    pub struct TimeMode3Flags : u16 {
+    pub struct CfgTmode3Flags: u16 {
         const DISABLED = 0x01;
         const SURVEY_IN = 0x02;
         const FIXED_MODE = 0x04;
@@ -1116,10 +1132,15 @@ bitflags! {
 }
 
 /// TP5: "Time Pulse" Config frame (32.10.38.4)
-#[ubx_packet_send]
-#[ubx(class = 6, id = 0x31, fixed_payload_len = 32)]
+#[ubx_packet_recv_send]
+#[ubx(
+    class = 0x06, 
+    id = 0x31, 
+    fixed_payload_len = 32,
+    flags = "default_for_builder"
+)]
 pub struct CfgTp5 {
-    #[ubx(map_type = TimePulseMode)]
+    #[ubx(map_type = CfgTp5TimePulseMode, may_fail)]
     tp_idx: u8,
     version: u8,
     reserved1: [u8; 2],
@@ -1155,12 +1176,18 @@ pub struct CfgTp5 {
 
 /// TimePulseMode used in CfgTp5 frame
 #[ubx_extend]
-#[ubx(into_raw)]
+#[ubx(from_unchecked, into_raw, rest_error)]
 #[repr(u8)]
 #[derive(Clone, Copy, Debug)]
-pub enum TimePulseMode {
+pub enum CfgTp5TimePulseMode {
     TimePulse = 0,
     TimePulse2 = 1,
+}
+
+impl Default for CfgTp5TimePulseMode {
+    fn default() -> Self {
+        Self::TimePulse
+    }
 }
 
 #[ubx_extend_bitflags]
@@ -2227,6 +2254,9 @@ define_recv_packets!(
         CfgPrtUart,
         CfgNav5,
         CfgAnt,
+        CfgTmode2,
+        CfgTmode3,
+        CfgTp5,
         InfError,
         InfWarning,
         InfNotice,

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1013,24 +1013,24 @@ struct CfgTmode2 {
     reserved1: u8,
     #[ubx(map_type = CfgTmode2Flags)] 
     flags: u16,
-    /// WGS84 ECEF.x coordinate or latitude,
+    /// WGS84 ECEF.x coordinate in [m] or latitude in [deg° *1E-5],
     /// depending on `flags` field 
     #[ubx(map_type = f64, scale = 1e-2)]
     ecef_x_or_lat: i32,
-    /// WGS84 ECEF.y coordinate or longitude,
+    /// WGS84 ECEF.y coordinate in [m] or longitude in [deg° *1E-5],
     /// depending on `flags` field 
     #[ubx(map_type = f64, scale = 1e-2)]
     ecef_y_or_lon: i32,
-    /// WGS84 ECEF.z coordinate or altitude,
+    /// WGS84 ECEF.z coordinate or altitude, both in [m],
     /// depending on `flags` field 
     #[ubx(map_type = f64, scale = 1e-2)]
     ecef_z_or_alt: i32,
-    /// Fixed position 3D accuracy [mm]
+    /// Fixed position 3D accuracy in [m]
     #[ubx(map_type = f64, scale = 1e-3)]
     fixed_pos_acc: u32,
-    /// Survey in minimum duration [s]
+    /// Survey in minimum duration in [s]
     survey_in_min_duration: u32,
-    /// Survey in position accuracy limit [mm]
+    /// Survey in position accuracy limit in [m]
     #[ubx(map_type = f64, scale = 1e-3)]
     survery_in_accur_limit: u32,
 }
@@ -1081,32 +1081,32 @@ struct CfgTmode3 {
     reserved1: u8,
     #[ubx(map_type = CfgTmode3Flags)] 
     flags: u16,
-    /// WGS84 ECEF.x coordinate or latitude,
+    /// WGS84 ECEF.x coordinate in [m] or latitude in [deg° *1E-5],
     /// depending on `flags` field 
     #[ubx(map_type = f64, scale = 1e-2)]
     ecef_x_or_lat: i32,
-    /// WGS84 ECEF.y coordinate or longitude,
+    /// WGS84 ECEF.y coordinate in [m] or longitude in [deg° *1E-5],
     /// depending on `flags` field 
     #[ubx(map_type = f64, scale = 1e-2)]
     ecef_y_or_lon: i32,
-    /// WGS84 ECEF.z coordinate or altitude,
+    /// WGS84 ECEF.z coordinate or altitude, both in [m], 
     /// depending on `flags` field 
     #[ubx(map_type = f64, scale = 1e-2)]
     ecef_z_or_alt: i32,
-    /// High precision WGS84 ECEF.x coordinate or latitude,
+    /// High precision WGS84 ECEF.x coordinate in [tenths of mm],
+    /// or high precision latitude, in nano degrees,
     /// depending on `flags` field.
-    /// Must be in range [-99, +99]
-    #[ubx(map_type = f32, scale = 1e-4)]
+    #[ubx(map_type = f32, scale = 1.0)]
     ecef_x_or_lat_hp: i8,
-    /// High precision WGS84 ECEF.y coordinate or longitude,
+    /// High precision WGS84 ECEF.y coordinate in [tenths of mm]
+    /// or high precision longitude, in nano degrees,
     /// depending on `flags` field.
-    /// Must be in range [-99, +99]
-    #[ubx(map_type = f32, scale = 1e-4)]
+    #[ubx(map_type = f32, scale = 1.0)]
     ecef_y_or_lon_hp: i8,
     /// High precision WGS84 ECEF.z coordinate or altitude,
+    /// both if tenths of [mm],
     /// depending on `flags` field.
-    /// Must be in range [-99, +99]
-    #[ubx(map_type = f32, scale = 1e-4)]
+    #[ubx(map_type = f32, scale = 1.0)]
     ecef_z_or_alt_hp: i8,
     reserved2: u8,
     /// Fixed position 3D accuracy [0.1 mm]
@@ -1145,30 +1145,31 @@ struct CfgTp5 {
     version: u8,
     reserved1: [u8; 2],
     /// Antenna cable delay [ns]
-    #[ubx(map_type = f32, scale = 1e-9)]
+    #[ubx(map_type = f32, scale = 1.0)]
     ant_cable_delay: i16,
     /// RF group delay [ns]
-    #[ubx(map_type = f32, scale = 1e-9)]
+    #[ubx(map_type = f32, scale = 1.0)]
     rf_group_delay: i16,
-    /// Frequency or Period time depending
-    /// on `isFreq` bit
-    #[ubx(map_type = f64, scale = 1e-6)]
+    /// Frequency in Hz or Period in us,
+    /// depending on `flags::IS_FREQ` bit
+    #[ubx(map_type = f64, scale = 1.0)]
     freq_period: u32, 
-    /// Frequency or Period time when locked [Hz] or [us]
-    /// to GNSS time, only used if `LockedOtherSet` bit is set
-    #[ubx(map_type = f64, scale = 1e-6)]
+    /// Frequency in Hz or Period in us,
+    /// when locked to GPS time.
+    /// Only used when `flags::LOCKED_OTHER_SET` is set
+    #[ubx(map_type = f64, scale = 1.0)]
     freq_period_lock: u32, 
-    /// Pulse length or duty cycle, [us] or [*2^-32]
-    /// depending on `isLength` bit
-    #[ubx(map_type = f64, scale = 1e-6)]
+    /// Pulse length or duty cycle, [us] or [*2^-32],
+    /// depending on `flags::LS_LENGTH` bit
+    #[ubx(map_type = f64, scale = 1.0)]
     pulse_len_ratio: u32,
-    /// Pulse Length or duty cycle [us] or [*2^-32], 
-    /// when locked to GNSS time,
-    /// only used if `LockedOtherSet` bit is set
-    #[ubx(map_type = f64, scale = 1e-6)]
-    pulse_len_ratio_locked: u32,
+    /// Pulse Length in us or duty cycle (*2^-32), 
+    /// when locked to GPS time.
+    /// Only used when `flags::LOCKED_OTHER_SET` is set
+    #[ubx(map_type = f64, scale = 1.0)]
+    pulse_len_ratio_lock: u32,
     /// User configurable time pulse delay in [ns]
-    #[ubx(map_type = f64, scale = 1e-9)]
+    #[ubx(map_type = f64, scale = 1.0)]
     user_delay: i32,
     /// Configuration flags, see [Tp5Flags]
     flags: u32,

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1171,7 +1171,8 @@ struct CfgTp5 {
     /// User configurable time pulse delay in [ns]
     #[ubx(map_type = f64, scale = 1.0)]
     user_delay: i32,
-    /// Configuration flags, see [Tp5Flags]
+    /// Configuration flags, see [CfgTp5Flags]
+    #[ubx(map_type = CfgTp5Flags)]
     flags: u32,
 }
 
@@ -1192,9 +1193,10 @@ impl Default for CfgTp5TimePulseMode {
 }
 
 #[ubx_extend_bitflags]
-#[ubx(into_raw, rest_reserved)]
+#[ubx(from, into_raw, rest_reserved)]
 bitflags! {
-    pub struct Tp5Flags: u32 {
+    #[derive(Default)]
+    pub struct CfgTp5Flags: u32 {
         // Enables time pulse
         const ACTIVE = 0x01;
         /// Synchronize time pulse to GNSS as

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1174,7 +1174,7 @@ struct CfgTp5 {
     flags: u32,
 }
 
-/// TimePulseMode used in CfgTp5 frame
+/// Time pulse selection, used in CfgTp5 frame
 #[ubx_extend]
 #[ubx(from_unchecked, into_raw, rest_error)]
 #[repr(u8)]

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1139,7 +1139,7 @@ bitflags! {
     fixed_payload_len = 32,
     flags = "default_for_builder"
 )]
-pub struct CfgTp5 {
+struct CfgTp5 {
     #[ubx(map_type = CfgTp5TimePulseMode, may_fail)]
     tp_idx: u8,
     version: u8,

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1079,8 +1079,11 @@ bitflags! {
 struct CfgTmode3 {
     version: u8,
     reserved1: u8,
+    /// Receiver mode, see [CfgTmode3RcvrMode] enum
+    #[ubx(map_type = CfgTmode3RcvrMode)]
+    rcvr_mode: u8,
     #[ubx(map_type = CfgTmode3Flags)] 
-    flags: u16,
+    flags: u8,
     /// WGS84 ECEF.x coordinate in [m] or latitude in [deg° *1E-5],
     /// depending on `flags` field 
     #[ubx(map_type = f64, scale = 1e-2)]
@@ -1124,10 +1127,22 @@ struct CfgTmode3 {
 #[ubx(from, into_raw, rest_reserved)]
 bitflags! {
     #[derive(Default)]
-    pub struct CfgTmode3Flags: u16 {
+    pub struct CfgTmode3RcvrMode: u8 {
         const DISABLED = 0x01;
         const SURVEY_IN = 0x02;
+        /// True ARP position is required in `FixedMode`
         const FIXED_MODE = 0x04;
+    }
+}
+
+#[ubx_extend_bitflags]
+#[ubx(from, into_raw, rest_reserved)]
+bitflags! {
+    #[derive(Default)]
+    pub struct CfgTmode3Flags: u8 {
+        /// Set if position is given in Lat/Lon/Alt,
+        /// ECEF coordinates being used otherwise
+        const LLA = 0x01;
     }
 }
 

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1007,7 +1007,7 @@ bitflags! {
     flags = "default_for_builder"
 )]
 struct CfgTmode2 {
-    /// Time transfer modes, see [TimeModes] for details
+    /// Time transfer modes, see [CfgTmode2TimeXferModes] for details
     #[ubx(map_type = CfgTmode2TimeXferModes, may_fail)]
     time_transfer_mode: u8,
     reserved1: u8,
@@ -1194,18 +1194,18 @@ impl Default for CfgTp5TimePulseMode {
 #[ubx(into_raw, rest_reserved)]
 bitflags! {
     pub struct Tp5Flags: u32 {
-        // Must be set for FTS variant,
-        // enables time pulse
+        // Enables time pulse
         const ACTIVE = 0x01;
         /// Synchronize time pulse to GNSS as
         /// soon as GNSS time is valid.
-        /// Use local lock otherwise
-        /// This bit is ignored by FTS product variants.
-        /// This flag can only be unset in Timing variants.
+        /// Uses local lock otherwise.
         const LOCK_GNSS_FREQ = 0x02;
-        /// TODO
+        /// use `freq_period_lock` and `pulse_len_ratio_lock`
+        /// fields as soon as GPS time is valid. Uses 
+        /// `freq_period` and `pulse_len_ratio` when GPS time is invalid.
         const LOCKED_OTHER_SET = 0x04;
-        /// Interprate frequency values instead of period values 
+        /// `freq_period` and `pulse_len_ratio` fields
+        /// are interprated as frequency when this bit is set
         const IS_FREQ = 0x08;
         /// Interprate pulse lengths instead of duty cycle
         const IS_LENGTH = 0x10;


### PR DESCRIPTION

Hello @lkolbly, @reitermarkus 

Before I get into this, I would like to congratulate you guys for this amazing lib.
I'm working on our new GNSS application, and this lib is at the core of it. 
This lib is high level, yet performant yet easy to use, which is the statement of good pieces of software.

I would like to introduce 3 timing oriented configuration frames

* `CfgTimeMode2` : only available on `T` class ublox receivers
* `CfgTimeMode3`: only available on `T` class ublox receivers
* `CfgTp5` : available on all ublox receivers

Because some fields have an `i16` and `i8` format, I added two new interpration methods