### PR TITLE
packet.rs: add cfgtp5 frame

### DIFF
--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -997,6 +997,118 @@ bitflags! {
     }
 }
 
+/// TP5: "Time Pulse" Config frame (32.10.38.4)
+#[ubx_packet_recv_send]
+#[ubx(
+    class = 0x06, 
+    id = 0x31, 
+    fixed_payload_len = 32,
+    flags = "default_for_builder"
+)]
+struct CfgTp5 {
+    #[ubx(map_type = CfgTp5TimePulseMode, may_fail)]
+    tp_idx: u8,
+    version: u8,
+    reserved1: [u8; 2],
+    /// Antenna cable delay [ns]
+    #[ubx(map_type = f32, scale = 1.0)]
+    ant_cable_delay: i16,
+    /// RF group delay [ns]
+    #[ubx(map_type = f32, scale = 1.0)]
+    rf_group_delay: i16,
+    /// Frequency in Hz or Period in us,
+    /// depending on `flags::IS_FREQ` bit
+    #[ubx(map_type = f64, scale = 1.0)]
+    freq_period: u32, 
+    /// Frequency in Hz or Period in us,
+    /// when locked to GPS time.
+    /// Only used when `flags::LOCKED_OTHER_SET` is set
+    #[ubx(map_type = f64, scale = 1.0)]
+    freq_period_lock: u32, 
+    /// Pulse length or duty cycle, [us] or [*2^-32],
+    /// depending on `flags::LS_LENGTH` bit
+    #[ubx(map_type = f64, scale = 1.0)]
+    pulse_len_ratio: u32,
+    /// Pulse Length in us or duty cycle (*2^-32), 
+    /// when locked to GPS time.
+    /// Only used when `flags::LOCKED_OTHER_SET` is set
+    #[ubx(map_type = f64, scale = 1.0)]
+    pulse_len_ratio_lock: u32,
+    /// User configurable time pulse delay in [ns]
+    #[ubx(map_type = f64, scale = 1.0)]
+    user_delay: i32,
+    /// Configuration flags, see [CfgTp5Flags]
+    #[ubx(map_type = CfgTp5Flags)]
+    flags: u32,
+}
+
+/// Time pulse selection, used in CfgTp5 frame
+#[ubx_extend]
+#[ubx(from_unchecked, into_raw, rest_error)]
+#[repr(u8)]
+#[derive(Clone, Copy, Debug)]
+pub enum CfgTp5TimePulseMode {
+    TimePulse = 0,
+    TimePulse2 = 1,
+}
+
+impl Default for CfgTp5TimePulseMode {
+    fn default() -> Self {
+        Self::TimePulse
+    }
+}
+
+#[ubx_extend_bitflags]
+#[ubx(from, into_raw, rest_reserved)]
+bitflags! {
+    #[derive(Default)]
+    pub struct CfgTp5Flags: u32 {
+        // Enables time pulse
+        const ACTIVE = 0x01;
+        /// Synchronize time pulse to GNSS as
+        /// soon as GNSS time is valid.
+        /// Uses local lock otherwise.
+        const LOCK_GNSS_FREQ = 0x02;
+        /// use `freq_period_lock` and `pulse_len_ratio_lock`
+        /// fields as soon as GPS time is valid. Uses 
+        /// `freq_period` and `pulse_len_ratio` when GPS time is invalid.
+        const LOCKED_OTHER_SET = 0x04;
+        /// `freq_period` and `pulse_len_ratio` fields
+        /// are interprated as frequency when this bit is set
+        const IS_FREQ = 0x08;
+        /// Interprate pulse lengths instead of duty cycle
+        const IS_LENGTH = 0x10;
+        /// Align pulse to top of second
+        /// Period time must be integer fraction of `1sec`
+        /// `LOCK_GNSS_FREQ` is expected, to unlock this feature
+        const ALIGN_TO_TOW = 0x20;
+        /// Pulse polarity, 
+        /// 0: falling edge @ top of second,
+        /// 1: rising edge @ top of second,
+        const POLARITY = 0x40;
+        /// UTC time grid
+        const UTC_TIME_GRID = 0x80;
+        /// GPS time grid
+        const GPS_TIME_GRID = 0x100;
+        /// GLO time grid
+        const GLO_TIME_GRID = 0x200;
+        /// BDS time grid
+        const BDS_TIME_GRID = 0x400;
+        /// GAL time grid
+        /// not supported in protocol < 18
+        const GAL_TIME_GRID = 0x800;
+        /// Switches to FreqPeriodLock and PulseLenRatio
+        /// as soon as Sync Manager has an accurate time,
+        /// never switches back
+        const SYNC_MODE_0 = 0x1000;
+        /// Switches to FreqPeriodLock and PulseLenRatioLock
+        /// as soon as Sync Manager has an accurante time,
+        /// and switch back to FreqPeriodLock and PulseLenRatio
+        /// when time gets inaccurate
+        const SYNC_MODE_1 = 0x2000;
+    }
+}
+
 #[ubx_extend_bitflags]
 #[ubx(into_raw, rest_reserved)]
 bitflags! {
@@ -1628,6 +1740,17 @@ impl Default for CfgNav5UtcStandard {
 struct ScaleBack<T: FloatCore + FromPrimitive + ToPrimitive>(T);
 
 impl<T: FloatCore + FromPrimitive + ToPrimitive> ScaleBack<T> {
+    fn as_i16(self, x: T) -> i16 {
+        let x = (x * self.0).round();
+        if x < T::from_i16(i16::min_value()).unwrap() {
+            i16::min_value()
+        } else if x > T::from_i16(i16::max_value()).unwrap() {
+            i16::max_value()
+        } else {
+            x.to_i16().unwrap()
+        }
+    }
+
     fn as_i32(self, x: T) -> i32 {
         let x = (x * self.0).round();
         if x < T::from_i32(i32::min_value()).unwrap() {
@@ -1990,6 +2113,7 @@ define_recv_packets!(
         CfgPrtUart,
         CfgNav5,
         CfgAnt,
+        CfgTp5,
         InfError,
         InfWarning,
         InfNotice,


### PR DESCRIPTION
Hello @lkolbly, @reitermarkus 

With this contribution I would like to introduce the `CfgTp5` configuration frame that is available on all receivers.

For ambiguous datafields that may have a different role, like `freq_period_lock` which can describe either
* a frequency value in `Hz`
* a period value in `us`

I set a scaling of 1.0 and documented the units properly

For RF delays values, I also used a scaling of 1.0 because `ns` is a convenient unit to deal with RF delays IMO

yours,