### PR TITLE
add feature for serdes

### DIFF
--- a/ublox/Cargo.toml
+++ b/ublox/Cargo.toml
@@ -12,7 +12,6 @@ readme = "../README.md"
 default = ["std"]
 std = []
 alloc = []
-use-serde = ["serde"]
 
 [dependencies]
 chrono = { version = "0.4.19", default-features = false, features = [] }

--- a/ublox/Cargo.toml
+++ b/ublox/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { version = "0.4.19", default-features = false, features = [] }
 bitflags = "1.2.1"
 ublox_derive = { path = "../ublox_derive", version = "0.0.4" }
 num-traits = { version = "0.2.12", default-features = false }
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 
 [build-dependencies]
 

--- a/ublox/Cargo.toml
+++ b/ublox/Cargo.toml
@@ -12,12 +12,14 @@ readme = "../README.md"
 default = ["std"]
 std = []
 alloc = []
+use-serde = ["serde"]
 
 [dependencies]
 chrono = { version = "0.4.19", default-features = false, features = [] }
 bitflags = "1.2.1"
 ublox_derive = { path = "../ublox_derive", version = "0.0.4" }
 num-traits = { version = "0.2.12", default-features = false }
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [build-dependencies]
 

--- a/ublox/src/lib.rs
+++ b/ublox/src/lib.rs
@@ -69,7 +69,7 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "use-serde")]
+#[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
 

--- a/ublox/src/lib.rs
+++ b/ublox/src/lib.rs
@@ -69,6 +69,10 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[cfg(feature = "use-serde")]
+#[macro_use]
+extern crate serde;
+
 pub use crate::{
     error::{DateTimeError, MemWriterError, ParserError},
     parser::{FixedLinearBuffer, Parser, ParserIter, UnderlyingBuffer},

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -319,7 +319,7 @@ struct NavSolution {
 #[ubx(from, rest_reserved)]
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq)]
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum GpsFix {
     NoFix = 0,
     DeadReckoningOnly = 1,
@@ -333,7 +333,7 @@ pub enum GpsFix {
 #[ubx(from, rest_reserved)]
 bitflags! {
     /// Navigation Status Flags
-    #[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct NavStatusFlags: u8 {
         /// position and velocity valid and within DOP and ACC Masks
         const GPS_FIX_OK = 1;
@@ -397,7 +397,7 @@ pub enum MapMatchingStatus {
 #[ubx(from, rest_reserved)]
 #[repr(u8)]
 #[derive(Debug, Copy, Clone)]
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 enum NavStatusFlags2 {
     Acquisition = 0,
     Tracking = 1,
@@ -535,7 +535,7 @@ impl fmt::Debug for NavSatSvFlags {
 }
 
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum NavSatQualityIndicator {
     NoSignal,
     Searching,
@@ -546,7 +546,7 @@ pub enum NavSatQualityIndicator {
 }
 
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum NavSatSvHealth {
     Healthy,
     Unhealthy,
@@ -554,7 +554,7 @@ pub enum NavSatSvHealth {
 }
 
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum NavSatOrbitSource {
     NoInfoAvailable,
     Ephemeris,
@@ -699,7 +699,7 @@ struct CfgOdo {
 #[ubx(from, into_raw, rest_reserved)]
 bitflags! {
     #[derive(Default)]
-    #[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct OdoCogFilterFlags: u8 {
         /// Odometer enabled flag
         const USE_ODO = 0x01;
@@ -717,7 +717,7 @@ bitflags! {
 #[ubx(from_unchecked, into_raw, rest_error)]
 #[repr(u8)]
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum OdoProfile {
     Running = 0,
     Cycling = 1,
@@ -991,7 +991,7 @@ struct CfgAnt {
 #[ubx(from, into_raw, rest_reserved)]
 bitflags! {
     #[derive(Default)]
-    #[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct AntFlags: u16 {
         /// Enable supply voltage control signal
         const SVCS = 0x01;
@@ -1010,7 +1010,7 @@ bitflags! {
 #[ubx(into_raw, rest_reserved)]
 bitflags! {
     /// Battery backed RAM sections to clear
-    #[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct NavBbrMask: u16 {
         const EPHEMERIS = 1;
         const ALMANACH = 2;
@@ -1048,7 +1048,7 @@ impl NavBbrPredefinedMask {
 /// Reset Type
 #[repr(u8)]
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ResetMode {
     /// Hardware reset (Watchdog) immediately
     HardwareResetImmediately = 0,
@@ -1130,7 +1130,7 @@ struct CfgPrtUart {
 #[ubx(from_unchecked, into_raw, rest_error)]
 #[repr(u8)]
 #[derive(Debug, Copy, Clone)]
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum UartPortId {
     Uart1 = 1,
     Uart2 = 2,
@@ -1138,7 +1138,7 @@ pub enum UartPortId {
 }
 
 #[derive(Debug, Copy, Clone)]
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UartMode {
     data_bits: DataBits,
     parity: Parity,
@@ -1174,7 +1174,7 @@ impl From<u32> for UartMode {
 }
 
 #[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DataBits {
     Seven,
     Eight,
@@ -1205,7 +1205,7 @@ impl From<u32> for DataBits {
 }
 
 #[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Parity {
     Even,
     Odd,
@@ -1238,7 +1238,7 @@ impl From<u32> for Parity {
 }
 
 #[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum StopBits {
     One,
     OneHalf,

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -319,6 +319,7 @@ struct NavSolution {
 #[ubx(from, rest_reserved)]
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 pub enum GpsFix {
     NoFix = 0,
     DeadReckoningOnly = 1,
@@ -332,6 +333,7 @@ pub enum GpsFix {
 #[ubx(from, rest_reserved)]
 bitflags! {
     /// Navigation Status Flags
+    #[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
     pub struct NavStatusFlags: u8 {
         /// position and velocity valid and within DOP and ACC Masks
         const GPS_FIX_OK = 1;
@@ -395,6 +397,7 @@ pub enum MapMatchingStatus {
 #[ubx(from, rest_reserved)]
 #[repr(u8)]
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 enum NavStatusFlags2 {
     Acquisition = 0,
     Tracking = 1,
@@ -532,6 +535,7 @@ impl fmt::Debug for NavSatSvFlags {
 }
 
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 pub enum NavSatQualityIndicator {
     NoSignal,
     Searching,
@@ -542,6 +546,7 @@ pub enum NavSatQualityIndicator {
 }
 
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 pub enum NavSatSvHealth {
     Healthy,
     Unhealthy,
@@ -549,6 +554,7 @@ pub enum NavSatSvHealth {
 }
 
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 pub enum NavSatOrbitSource {
     NoInfoAvailable,
     Ephemeris,
@@ -693,6 +699,7 @@ struct CfgOdo {
 #[ubx(from, into_raw, rest_reserved)]
 bitflags! {
     #[derive(Default)]
+    #[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
     pub struct OdoCogFilterFlags: u8 {
         /// Odometer enabled flag
         const USE_ODO = 0x01;
@@ -710,6 +717,7 @@ bitflags! {
 #[ubx(from_unchecked, into_raw, rest_error)]
 #[repr(u8)]
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 pub enum OdoProfile {
     Running = 0,
     Cycling = 1,
@@ -983,6 +991,7 @@ struct CfgAnt {
 #[ubx(from, into_raw, rest_reserved)]
 bitflags! {
     #[derive(Default)]
+    #[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
     pub struct AntFlags: u16 {
         /// Enable supply voltage control signal
         const SVCS = 0x01;
@@ -1001,6 +1010,7 @@ bitflags! {
 #[ubx(into_raw, rest_reserved)]
 bitflags! {
     /// Battery backed RAM sections to clear
+    #[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
     pub struct NavBbrMask: u16 {
         const EPHEMERIS = 1;
         const ALMANACH = 2;
@@ -1038,6 +1048,7 @@ impl NavBbrPredefinedMask {
 /// Reset Type
 #[repr(u8)]
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 pub enum ResetMode {
     /// Hardware reset (Watchdog) immediately
     HardwareResetImmediately = 0,
@@ -1119,6 +1130,7 @@ struct CfgPrtUart {
 #[ubx(from_unchecked, into_raw, rest_error)]
 #[repr(u8)]
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 pub enum UartPortId {
     Uart1 = 1,
     Uart2 = 2,
@@ -1126,6 +1138,7 @@ pub enum UartPortId {
 }
 
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 pub struct UartMode {
     data_bits: DataBits,
     parity: Parity,
@@ -1161,6 +1174,7 @@ impl From<u32> for UartMode {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 pub enum DataBits {
     Seven,
     Eight,
@@ -1191,6 +1205,7 @@ impl From<u32> for DataBits {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 pub enum Parity {
     Even,
     Odd,
@@ -1223,6 +1238,7 @@ impl From<u32> for Parity {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 pub enum StopBits {
     One,
     OneHalf,

--- a/ublox/src/ubx_packets/types.rs
+++ b/ublox/src/ubx_packets/types.rs
@@ -4,6 +4,7 @@ use chrono::prelude::*;
 use core::convert::TryFrom;
 
 /// Represents a world position, can be constructed from NavPosLlh and NavPosVelTime packets.
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy)]
 pub struct Position {
     /// Logitude in degrees
@@ -17,6 +18,7 @@ pub struct Position {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 pub struct Velocity {
     /// m/s over the ground
     pub speed: f64,

--- a/ublox/src/ubx_packets/types.rs
+++ b/ublox/src/ubx_packets/types.rs
@@ -4,7 +4,7 @@ use chrono::prelude::*;
 use core::convert::TryFrom;
 
 /// Represents a world position, can be constructed from NavPosLlh and NavPosVelTime packets.
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy)]
 pub struct Position {
     /// Logitude in degrees
@@ -18,7 +18,7 @@ pub struct Position {
 }
 
 #[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Velocity {
     /// m/s over the ground
     pub speed: f64,


### PR DESCRIPTION
Hello @lkolbly,
I'm building an application that involves an `ublox` and I need the user to control and parametrize it.
Having the `serdes` capacity would really help. With this commit I introduce a new `use-serde` build feature and some serdes derivation. I am mostly interested in `GpsFix`, `Odo` options and `Ant` options