### PR TITLE
ubx_packets: introduce MonGnss

### DIFF
--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1884,7 +1884,7 @@ struct MonGnss {
 #[ubx_extend_bitflags]
 #[ubx(from, into_raw, rest_reserved)]
 bitflags! {
-    /// Synchronization Manager config flags
+    /// Selected / available Constellation Mask 
     #[derive(Default)]
     pub struct MonGnssConstellMask: u8 {
         /// GPS constellation

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1862,6 +1862,42 @@ pub enum AntennaStatus {
     Open = 4,
 }
 
+/// GNSS status monitoring,
+/// gives currently selected constellations
+#[ubx_packet_recv]
+#[ubx(class = 0x0a, id = 0x28, fixed_payload_len = 7)]
+struct MonGnss {
+    /// Message version: 0x00 for this version
+    version: u8,
+    /// List of supported Major constellations
+    #[ubx(map_type = MonGnssConstellMask)]
+    supported: u8,
+    /// List of currently enabled Major constellations
+    #[ubx(map_type = MonGnssConstellMask)]
+    enabled: u8,
+    /// Maximum number of concurent Major GNSS
+    /// that can be supported by this receiver
+    simultaneous: u8,
+    reserved1: [u8; 3],
+}
+
+#[ubx_extend_bitflags]
+#[ubx(from, into_raw, rest_reserved)]
+bitflags! {
+    /// Synchronization Manager config flags
+    #[derive(Default)]
+    pub struct MonGnssConstellMask: u8 {
+        /// GPS constellation
+        const GPS = 0x01;
+        /// GLO constellation
+        const GLO = 0x02;
+        /// BDC constellation
+        const BDC = 0x04;
+        /// GAL constellation
+        const GAL = 0x08;
+    }
+}
+
 #[ubx_extend]
 #[ubx(from, rest_reserved)]
 #[repr(u8)]
@@ -1996,6 +2032,7 @@ define_recv_packets!(
         InfTest,
         InfDebug,
         MonVer,
+        MonGnss,
         MonHw,
         RxmRtcm
     }

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1865,14 +1865,17 @@ pub enum AntennaStatus {
 /// GNSS status monitoring,
 /// gives currently selected constellations
 #[ubx_packet_recv]
-#[ubx(class = 0x0a, id = 0x28, fixed_payload_len = 7)]
+#[ubx(class = 0x0a, id = 0x28, fixed_payload_len = 8)]
 struct MonGnss {
-    /// Message version: 0x00 for this version
+    /// Message version: 0x00
     version: u8,
-    /// List of supported Major constellations
+    /// Supported major constellations bit mask
     #[ubx(map_type = MonGnssConstellMask)]
     supported: u8,
-    /// List of currently enabled Major constellations
+    /// Default major GNSS constellations bit mask
+    #[ubx(map_type = MonGnssConstellMask)]
+    default: u8,
+    /// Currently enabled major constellations bit mask
     #[ubx(map_type = MonGnssConstellMask)]
     enabled: u8,
     /// Maximum number of concurent Major GNSS


### PR DESCRIPTION
Hello @lkolbly,

`MonGnss` status frame gives:
*  which constellations are currently active 
* what the receiver is capable of (Multi carrier, etc..) 