### PR TITLE
Fix typo in proto mask name

### DIFF
--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1290,7 +1290,7 @@ bitflags! {
     /// Used in `CfgPrtSpi` and `CfgPrtI2c`
     #[derive(Default)]
     pub struct InProtoMask: u16 {
-        const UBOX = 1;
+        const UBLOX = 1;
         const NMEA = 2;
         const RTCM = 4;
         /// The bitfield inRtcm3 is not supported in protocol


### PR DESCRIPTION
Simple typo fix: `UBOX` -> `UBLOX`.