### PR TITLE
Fix compilation on `no_std`.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,18 +2,20 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        feature-args:
+          - ''
+          - --no-default-features --features alloc
+          - --no-default-features
     steps:
     - uses: actions/checkout@v2
     - name: Install libudev
@@ -25,6 +27,6 @@ jobs:
         override: true
         components: rustfmt, clippy
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose ${{ matrix.feature-args }}
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose ${{ matrix.feature-args }}

--- a/ublox_derive/Cargo.toml
+++ b/ublox_derive/Cargo.toml
@@ -13,6 +13,7 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0.14", features = ["extra-traits", "full"] }
+
 [dev-dependencies]
 which = { version = "3.0", default-features = false }
 proc-macro2 = { version = "1.0", features = ["span-locations"] }

--- a/ublox_derive/src/output.rs
+++ b/ublox_derive/src/output.rs
@@ -444,6 +444,7 @@ pub fn generate_send_code_for_packet(pack_descr: &PackDesc) -> TokenStream {
     } else {
         ret.extend(quote! {
           impl #payload_struct_lifetime #payload_struct #payload_struct_lifetime {
+              #[cfg(feature = "alloc")]
               #[inline]
               pub fn into_packet_vec(self) -> Vec<u8> {
                 let mut vec = Vec::new();


### PR DESCRIPTION
https://github.com/lkolbly/ublox/pull/42 broke compilation without any features, since `Vec` isn't available for the `into_packet_vec` function.